### PR TITLE
Calling wait helper gives 'resolve is not defined' error.

### DIFF
--- a/app/assets/javascripts/netzke/testing/helpers/actions.js.coffee
+++ b/app/assets/javascripts/netzke/testing/helpers/actions.js.coffee
@@ -44,7 +44,7 @@ Ext.apply window,
       #   waitAtLeast50Seconds()
       if Ext.isFunction(arguments[1])
         delay = arguments[0]
-        callback = arguments[1]
+        resolve = arguments[1]
         setInterval ->
           waitInCycle(resolve)
         , delay

--- a/spec/features/javascripts/foo.js.coffee
+++ b/spec/features/javascripts/foo.js.coffee
@@ -4,3 +4,6 @@ describe 'Foo', ->
 
   it 'shows as a panel with title "Test component"', ->
     expectToSee header "Test component"
+
+  it 'can wait with a timeout and a callback function', ->
+    wait 1, ->


### PR DESCRIPTION
Calling the JavaScript test helper function `wait()` with a timeout and callback function causes a mocha test to always fail with an error of `Error: ReferenceError: resolve is not defined`
